### PR TITLE
[codex] Add CPU CI baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,21 @@ jobs:
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
             git diff --check "${{ github.event.before }}" HEAD
           else
-            git diff --check HEAD
+            git diff-tree --check --root -r --no-commit-id HEAD
           fi
 
       - name: Build shared package
         run: uv build --project src --sdist --wheel
 
       - name: Check recipe lockfiles
+        shell: bash
         run: |
-          uv lock --check --project recipes/alpamayo1_sft
-          uv lock --check --project recipes/alpamayo1_5_sft
-          uv lock --check --project recipes/alpamayo1_x_rl
+          set -euo pipefail
+
+          for pyproject in recipes/*/pyproject.toml; do
+            recipe_dir="$(dirname "$pyproject")"
+            uv lock --check --project "$recipe_dir"
+          done
 
       - name: Compile Python sources
         run: python -m compileall -q src scripts recipes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cpu:
+    name: CPU baseline
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Check changed-file whitespace
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git diff --check "${{ github.event.pull_request.base.sha }}" HEAD
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
+            git diff --check "${{ github.event.before }}" HEAD
+          else
+            git diff --check HEAD
+          fi
+
+      - name: Build shared package
+        run: uv build --project src --sdist --wheel
+
+      - name: Check recipe lockfiles
+        run: |
+          uv lock --check --project recipes/alpamayo1_sft
+          uv lock --check --project recipes/alpamayo1_5_sft
+          uv lock --check --project recipes/alpamayo1_x_rl
+
+      - name: Compile Python sources
+        run: python -m compileall -q src scripts recipes
+
+      - name: Run CPU tests
+        run: uv run --with pytest pytest tests -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 __pycache__/
+.pytest_cache/
+.venv/
+**/.venv/
+dist/
 outputs/*
 *.egg-info
 output_stage*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,9 +265,10 @@ The repository CI runs a CPU-only baseline on pull requests and pushes to `main`
 
 ```bash
 uv build --project src --sdist --wheel
-uv lock --check --project recipes/alpamayo1_sft
-uv lock --check --project recipes/alpamayo1_5_sft
-uv lock --check --project recipes/alpamayo1_x_rl
+for pyproject in recipes/*/pyproject.toml; do
+  recipe_dir="$(dirname "$pyproject")"
+  uv lock --check --project "$recipe_dir"
+done
 python -m compileall -q src scripts recipes
 uv run --with pytest pytest tests -q
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,11 @@ git push -u origin <local-branch>:<remote-branch>
 - At least one Alpamayo researcher will be assigned for the review.
 - While under review, mark your PRs as work-in-progress by prefixing the PR title with [WIP].
 
-4. Since there is no CI/CD process in place yet, the PR will be accepted and the corresponding issue closed only after adequate testing has been completed, manually, by the developer and/or Alpamayo researcher reviewing the code.
+4. Basic CPU-only CI runs on pull requests and pushes to `main`. The required baseline checks
+   validate whitespace in changed files, shared-package buildability, recipe lockfiles, Python
+   syntax, and lightweight repository tests. PRs that touch heavy training, inference, dataset, or
+   model-loading paths still need appropriate manual validation by the developer and/or Alpamayo
+   researcher reviewing the code.
 
 #### Signing Your Work
 
@@ -257,9 +261,21 @@ uv sync --active
 python -m compileall .
 ```
 
-If the recipe includes tests, run them from the recipe environment. If full training or evaluation
-requires gated datasets, large checkpoints, or multi-GPU hardware, include the smaller smoke test
-you ran and document any heavyweight validation that maintainers would need to run separately.
+The repository CI runs a CPU-only baseline on pull requests and pushes to `main`:
+
+```bash
+uv build --project src --sdist --wheel
+uv lock --check --project recipes/alpamayo1_sft
+uv lock --check --project recipes/alpamayo1_5_sft
+uv lock --check --project recipes/alpamayo1_x_rl
+python -m compileall -q src scripts recipes
+uv run --with pytest pytest tests -q
+```
+
+If the recipe includes tests, run them from the recipe environment. If full training, evaluation,
+or recipe runtime coverage requires gated datasets, large checkpoints, Torch runtime setup,
+specialized kernels, or multi-GPU hardware, include the smaller smoke test you ran and document any
+heavyweight validation that maintainers would need to run separately.
 
 ### Recipe Pull Request Scope
 

--- a/tests/test_ci_baseline.py
+++ b/tests/test_ci_baseline.py
@@ -15,24 +15,37 @@ def _load_toml(path: Path) -> dict:
         return tomllib.load(handle)
 
 
+def _workflow_job_block(workflow: str, job_name: str) -> str:
+    lines = workflow.splitlines()
+    start = lines.index(f"  {job_name}:")
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if line.startswith("  ") and not line.startswith("    ") and line.strip().endswith(":"):
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
 def test_cpu_ci_workflow_runs_required_baseline_checks() -> None:
     workflow = CI_WORKFLOW.read_text()
+    cpu_job = _workflow_job_block(workflow, "cpu")
 
     required_commands = [
         "uv build --project src --sdist --wheel",
         "python -m compileall -q src scripts recipes",
-        "uv lock --check --project recipes/alpamayo1_sft",
-        "uv lock --check --project recipes/alpamayo1_5_sft",
-        "uv lock --check --project recipes/alpamayo1_x_rl",
+        "for pyproject in recipes/*/pyproject.toml; do",
+        'recipe_dir="$(dirname "$pyproject")"',
+        'uv lock --check --project "$recipe_dir"',
         "uv run --with pytest pytest tests -q",
     ]
     for command in required_commands:
-        assert command in workflow
+        assert command in cpu_job
 
     heavy_runtime_terms = ("flash-attn", "vllm", "cuda", "gpu", "nvidia-smi")
-    workflow_lower = workflow.lower()
+    cpu_job_lower = cpu_job.lower()
     for term in heavy_runtime_terms:
-        assert term not in workflow_lower
+        assert term not in cpu_job_lower
 
 
 def test_shared_package_build_metadata_stays_lightweight() -> None:

--- a/tests/test_ci_baseline.py
+++ b/tests/test_ci_baseline.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RECIPES_DIR = ROOT / "recipes"
+RECIPE_DIRS = tuple(sorted(path for path in RECIPES_DIR.iterdir() if path.is_dir()))
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _load_toml(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def test_cpu_ci_workflow_runs_required_baseline_checks() -> None:
+    workflow = CI_WORKFLOW.read_text()
+
+    required_commands = [
+        "uv build --project src --sdist --wheel",
+        "python -m compileall -q src scripts recipes",
+        "uv lock --check --project recipes/alpamayo1_sft",
+        "uv lock --check --project recipes/alpamayo1_5_sft",
+        "uv lock --check --project recipes/alpamayo1_x_rl",
+        "uv run --with pytest pytest tests -q",
+    ]
+    for command in required_commands:
+        assert command in workflow
+
+    heavy_runtime_terms = ("flash-attn", "vllm", "cuda", "gpu", "nvidia-smi")
+    workflow_lower = workflow.lower()
+    for term in heavy_runtime_terms:
+        assert term not in workflow_lower
+
+
+def test_shared_package_build_metadata_stays_lightweight() -> None:
+    pyproject = _load_toml(ROOT / "src" / "pyproject.toml")
+
+    assert pyproject["project"]["name"] == "alpamayo-recipes"
+    assert pyproject["project"]["requires-python"] == "==3.12.*"
+    assert pyproject["project"]["dependencies"] == []
+    assert pyproject["build-system"]["build-backend"] == "hatchling.build"
+    assert pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"] == ["alpamayo"]
+
+
+def test_recipe_packages_keep_recipe_local_metadata() -> None:
+    assert RECIPE_DIRS
+
+    for recipe_dir in RECIPE_DIRS:
+        pyproject_path = recipe_dir / "pyproject.toml"
+        readme_path = recipe_dir / "README.md"
+        lockfile_path = recipe_dir / "uv.lock"
+
+        assert pyproject_path.is_file(), f"{recipe_dir} must define recipe-local metadata"
+        assert readme_path.is_file(), f"{recipe_dir} must document installation and usage"
+        assert lockfile_path.is_file(), f"{recipe_dir} must pin a recipe-local uv lockfile"
+
+        pyproject = _load_toml(pyproject_path)
+        dependencies = pyproject["project"]["dependencies"]
+        package_finder = pyproject["tool"]["setuptools"]["packages"]["find"]
+        uv_sources = pyproject["tool"]["uv"]["sources"]
+
+        assert pyproject["project"]["requires-python"] == "==3.12.*"
+        assert pyproject["build-system"]["build-backend"] == "setuptools.build_meta"
+        assert "alpamayo-recipes" in dependencies
+        assert package_finder["where"] == [".."]
+        assert package_finder["include"] == [f"{recipe_dir.name}*"]
+        assert uv_sources["alpamayo-recipes"] == {"path": "../../src", "editable": True}


### PR DESCRIPTION
## Summary

Adds the first GitHub Actions baseline for Alpamayo Recipes. The workflow runs on PRs, pushes to `main`, and manual dispatch, and is intentionally CPU-only/public-fork-safe.

It also updates `CONTRIBUTING.md`, adds lightweight tests for the CI/package conventions, and ignores local pytest/venv/build artifacts.

## CI Coverage

The required `CPU baseline` job checks:

- whitespace on PR/push ranges, or the selected commit for manual runs
- shared `src` package buildability with `uv build`
- every recipe project discovered via `recipes/*/pyproject.toml` with `uv lock --check`
- Python syntax with `compileall`
- lightweight pytest coverage for the workflow and recipe-local packaging rules

Heavy runtime validation remains manual/optional for changes that need Torch, flash-attn, vLLM, CUDA/GPU runners, gated datasets, or model checkpoints.

## Validation

- Local baseline: diff check, `uv build`, dynamic recipe lockfile loop, `compileall`, and pytest all passed.
- GitHub Actions: `CI / CPU baseline` passed on latest head `af37e0a`.