### PR TITLE
Document expert model AlpaGym scope

### DIFF
--- a/recipes/alpamayo1_x_rl/README.md
+++ b/recipes/alpamayo1_x_rl/README.md
@@ -435,6 +435,13 @@ text and discrete trajectory tokens. The action expert
 head (flow-matching-based continuous actions) is **not** trained
 by this RL pipeline. RL post-training for the **action expert pathway** will come in a future release.
 
+The `models/expert_model/` package is currently an importable support layer
+for AlpaGym closed-loop action expert RL integration. It is not a standalone
+action expert RL recipe in this repository and does not add new public
+`cosmos-rl` launch commands, recipe TOMLs, rollout backends, trainers, or
+rewards here. See [`models/expert_model/README.md`](models/expert_model/README.md)
+for the integration boundary.
+
 </details>
 
 <details>

--- a/recipes/alpamayo1_x_rl/models/expert_model/README.md
+++ b/recipes/alpamayo1_x_rl/models/expert_model/README.md
@@ -13,14 +13,8 @@ separate vendored copy.
 This directory is intended for the AlpaGym closed-loop RL integration.
 
 It is not a standalone action expert RL recipe in `alpamayo-recipes`. In
-particular, this package does not add:
-
-- a public `cosmos-rl` launch entrypoint for action expert RL
-- a recipe TOML for action expert RL
-- a rollout backend, trainer, reward, or data packer for standalone action
-  expert RL in this repository
-- user-facing instructions for running open-loop action expert RL from this
-  repository
+particular, this package does not add user-facing instructions for running
+open-loop action expert RL from this repository.
 
 Existing `alpamayo1_x_rl` users should continue to treat the documented
 recipe entrypoints under `models/reasoning_vla/` as the supported open-loop
@@ -36,7 +30,3 @@ The expected boundary is:
   diffusion support for AlpaGym
 - AlpaGym: closed-loop environment interaction, orchestration, and launch
   integration
-
-If a standalone action expert RL recipe is released from this repository in the
-future, it should add its own entrypoint, TOML config, data packing, validation
-path, and README instructions rather than relying on this support package alone.

--- a/recipes/alpamayo1_x_rl/models/expert_model/README.md
+++ b/recipes/alpamayo1_x_rl/models/expert_model/README.md
@@ -1,0 +1,42 @@
+# Action Expert Model Support for AlpaGym
+
+This package contains model-side support for closed-loop reinforcement
+learning of the Alpamayo diffusion action expert through AlpaGym.
+
+The code in this directory was added so AlpaGym can import the action expert
+Cosmos-RL wrapper, SDE-aware flow-matching diffusion utilities, and GRPO
+log-probability replay logic from `alpamayo1_x_rl` instead of carrying a
+separate vendored copy.
+
+## Scope
+
+This directory is intended for the AlpaGym closed-loop RL integration.
+
+It is not a standalone action expert RL recipe in `alpamayo-recipes`. In
+particular, this package does not add:
+
+- a public `cosmos-rl` launch entrypoint for action expert RL
+- a recipe TOML for action expert RL
+- a rollout backend, trainer, reward, or data packer for standalone action
+  expert RL in this repository
+- user-facing instructions for running open-loop action expert RL from this
+  repository
+
+Existing `alpamayo1_x_rl` users should continue to treat the documented
+recipe entrypoints under `models/reasoning_vla/` as the supported open-loop
+VLM RL workflow. The top-level `alpamayo1_x_rl` README remains the source of
+truth for the currently documented recipe commands.
+
+## Integration Boundary
+
+The expected boundary is:
+
+- `alpamayo_r1`: released Alpamayo model primitives
+- `alpamayo1_x_rl.models.expert_model`: importable action expert model and
+  diffusion support for AlpaGym
+- AlpaGym: closed-loop environment interaction, orchestration, and launch
+  integration
+
+If a standalone action expert RL recipe is released from this repository in the
+future, it should add its own entrypoint, TOML config, data packing, validation
+path, and README instructions rather than relying on this support package alone.


### PR DESCRIPTION
## Summary

- Add a README beside the new expert-model support package from PR #18.
- Clarify that this package is intended for AlpaGym closed-loop RL integration only.
- State explicitly that this does not add a standalone action-expert RL recipe, TOML, rollout backend, trainer, reward, or launch instructions in alpamayo-recipes.

## Validation

- git diff --cached --check
- git diff --check origin/pr/18..HEAD

## Context

This targets PR #18's branch, thomast/expert_wrapper_file, to reduce confusion for existing alpamayo1_x_rl users reviewing the new expert-model files.